### PR TITLE
default value for stream.path

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -233,6 +233,7 @@ class JsonClient
 
         # files is not a string and is not an array so it is a stream
         else if not Array.isArray files
+            files.path = files.path || "useless_But_Required_String" #require by formData
             form.append "file", files
 
         # files is an array of strings and streams


### PR DESCRIPTION
Hello,

To fix this this curious things :
https://github.com/felixge/node-form-data/blob/master/lib/form_data.js#L151

and avoid this kind of comment :
https://github.com/cozy/cozy-files/blob/master/server/controllers/files.coffee#L185-L187

NB: I spent 3 hours finding why this code didn't work :
```
pass = require('stream').PassThrough
 
 
https.get url, (stream)->
  resizeThumb = im().resize('300x300')
  resizeScreen = im().resize('1200x800')
  raw = new pass
  thumb = new pass
  screen = new pass
  stream.pipe(raw)
  stream.pipe(thumb)
  stream.pipe(screen)
 
  async.series [
      (cb) ->
          console.log "raw"
          p.attachBinary raw,
          {name: 'raw', type: photoData.type}, cb
      (cb) ->
          console.log "raw"
          p.attachBinary thumb.pipe(resizeThumb),
          {name: 'thumb', type: photoData.type}, cb
      (cb) ->
          console.log "raw"
          p.attachBinary thumb.pipe(resizeScreen),
          {name: 'screen', type: photoData.type}, cb
  ], (err)->
      console.log err
      next err
```

and I fixed it with :
```
            thumbStream = thumb.pipe(resizeThumb)
            thumbStream.path = 'untruc'
            screenStream = screen.pipe(resizeScreen)
            screenStream.path = 'untruc'
```
 
Bye