### PR TITLE
Improve error message

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -99,6 +99,9 @@ playRequest = (opts, data, callback, parse=true) ->
             parseBody null, res, body, callback, parse
 
     req.on 'error', (err) ->
+        err.message = """
+          #{err.code} on #{opts.method} #{opts.protocol}://#{opts.host}#{opts.port}#{opts.path}
+        """
         callback err
 
     req.write data if data?


### PR DESCRIPTION
In error logs, we saw a lot of ECONNREFUSED messages. They are pretty useless if we don't know which remote host has refused to connect, so this commit try to add some informations to the error message.
Once merged and published, we'll need to update cozydb and other projects relying on this lib.