### PR TITLE
Revert "Escape characters without changing '/' characters"

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -4,7 +4,6 @@ url = require 'url'
 http = require 'http'
 https = require 'https'
 mime = require 'mime'
-querystring = require 'querystring'
 
 
 # Merge two objects in one. Values from the second object win over the first
@@ -43,7 +42,7 @@ buildOptions = (clientOptions, clientHeaders, host, path, requestOptions) ->
     options.host = urlData.host.split(':')[0]
     options.port = urlData.port
     options.protocol = urlData.protocol
-    options.path = querystring.escape(path).replace /%2F/g, '/'
+    options.path = path
     if urlData.protocol is 'https:'
         options.requestFactory = https
         options.rejectUnauthorized = false
@@ -101,7 +100,7 @@ playRequest = (opts, data, callback, parse=true) ->
 
     req.on 'error', (err) ->
         err.message = """
-#{err.code} on #{opts.method} #{opts.protocol}://#{opts.host}#{opts.port}#{opts.path}
+          #{err.code} on #{opts.method} #{opts.protocol}://#{opts.host}#{opts.port}#{opts.path}
         """
         callback err
 

--- a/tests.coffee
+++ b/tests.coffee
@@ -2,7 +2,6 @@ should = require('chai').Should()
 http = require 'http'
 https = require 'https'
 path = require 'path'
-querystring = require 'querystring'
 express = require 'express'
 fs = require 'fs'
 bodyParser = require 'body-parser'
@@ -667,30 +666,4 @@ describe 'Request an https server', ->
         it 'Then I get msg: ok as answer.', ->
             should.exist @body.msg
             @body.msg.should.equal 'https ok'
-
-describe 'Request with unescaped characters', ->
-
-    describe 'client.get', ->
-
-        before ->
-            @serverGet = fakeServer msg:'ok', 200, (body, req) ->
-                req.method.should.equal 'GET'
-                querystring.unescape(req.url).should.equal  '/test-path & ~ /'
-            @serverGet.listen 8888
-            @client = request.newClient 'http://localhost:8888/'
-
-        after ->
-            @serverGet.close()
-
-        it 'When I send get request to server', (done) ->
-            @client.get '/test-path & ~ /', (error, response, body) =>
-                should.not.exist error
-                response.statusCode.should.be.equal 200
-                @body = body
-                done()
-
-        it 'Then I get msg: ok as answer.', ->
-            should.exist @body.msg
-            @body.msg.should.equal 'ok'
-
 


### PR DESCRIPTION
This reverts commit 80ee1e07c7163fce48abc3ef99a6c4d256478854.

It's the follow-up of comments here: https://github.com/cozy-labs/request-json-light/commit/80ee1e07c7163fce48abc3ef99a6c4d256478854#commitcomment-17664105